### PR TITLE
Update to modern-normalize@0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <p align="center"><img src="https://assets-cdn.github.com/favicon.ico" width=24 height=24/> <a href="https://github.com/arcticicestudio/styled-modern-normalize/releases/latest"><img src="https://img.shields.io/github/release/arcticicestudio/styled-modern-normalize.svg?style=flat-square"/></a> <img src="https://www.npmjs.com/static/images/touch-icons/favicon-32x32.png" width=24 height=24/> <a href="https://www.npmjs.com/package/styled-modern-normalize"><img src="https://img.shields.io/npm/v/styled-modern-normalize.svg?style=flat-square"/></a> <a href="https://www.npmjs.com/package/styled-modern-normalize"><img src="https://img.shields.io/npm/dt/styled-modern-normalize.svg?style=flat-square"/></a> <a href="https://www.npmjs.com/package/styled-modern-normalize"><img src="https://img.shields.io/npm/dm/styled-modern-normalize.svg?style=flat-square"/></a></p>
 
-<p align="center"><a href="https://github.com/arcticicestudio/styleguide-javascript"><img src="https://img.shields.io/badge/modern--normalize.css-0.4.0-5E81AC.svg?style=flat-square"/></a></p>
+<p align="center"><a href="https://github.com/arcticicestudio/styleguide-javascript"><img src="https://img.shields.io/badge/modern--normalize.css-0.5.0-5E81AC.svg?style=flat-square"/></a></p>
 
 # 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 <p align="center"><img src="https://circleci.com/favicon.ico" width=24 height=24/> <a href="https://circleci.com/gh/arcticicestudio/styled-modern-normalize"><img src="https://img.shields.io/circleci/project/github/arcticicestudio/styled-modern-normalize/develop.svg?style=flat-square"/></a> <img src="https://cdn.travis-ci.org/images/favicon-c566132d45ab1a9bcae64d8d90e4378a.svg" width=24 height=24/> <a href="https://travis-ci.org/arcticicestudio/styled-modern-normalize"><img src="https://img.shields.io/travis/arcticicestudio/styled-modern-normalize/develop.svg?style=flat-square"/></a></p>
 
-<p align="center"><a href="https://github.com/arcticicestudio/styled-modern-normalize/blob/develop/CHANGELOG.md#010"><img src="https://img.shields.io/badge/Changelog-0.1.0-5E81AC.svg?style=flat-square"/></a> <a href="https://github.com/arcticicestudio/styleguide-javascript"><img src="https://img.shields.io/badge/modern--normalize.css-0.4.0-5E81AC.svg?style=flat-square"/></a></p>
+<p align="center"><a href="https://github.com/arcticicestudio/styled-modern-normalize/blob/develop/CHANGELOG.md#010"><img src="https://img.shields.io/badge/Changelog-0.1.0-5E81AC.svg?style=flat-square"/></a> <a href="https://github.com/arcticicestudio/styleguide-javascript"><img src="https://img.shields.io/badge/modern--normalize.css-0.5.0-5E81AC.svg?style=flat-square"/></a></p>
 
 A common import method for `modern-normalize.css` is to use [unnamed imports][mdn-import] which works fine for projects with _vanilla_ CSS or pre-processors workflows like Sass/Less and a bundler like [webpack][], but it doesn't make use of the advantages of CSS-in-JS libraries like _styled-components_, e.g. auto-prefixing and CSS optimizing.
 
 [styled-modern-normalize][npm-styled-modern-normalize] is a proxy package of [modern-normalize.css][npm-modern-normalize] for [styled-components][] to provide the CSS as template literal with interpolation by using _styled-component_'s [`css`][sc-doc-api-css] API function. This allows to import and use it via [`injectGlobal`][sc-doc-api-injectglobal] or any other styled component.
 
-The package is based on and compatible with _modern-normalize.css_ version 0.4.0.
+The package is based on and compatible with _modern-normalize.css_ version 0.5.0.
 
 ## Getting Started
 
@@ -84,7 +84,7 @@ The version of _modern-normalize.css_ this package is currently based is exporte
 import { MODERN_NORMALIZE_VERSION } from "styled-modern-normalize";
 
 // Example:
-console.log(MODERN_NORMALIZE_VERSION); // "0.4.0"
+console.log(MODERN_NORMALIZE_VERSION); // "0.5.0"
 ```
 
 ### Development Workflow

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@
 
 import { css } from "styled-components";
 
-const MODERN_NORMALIZE_VERSION = "0.4.0";
+const MODERN_NORMALIZE_VERSION = "0.5.0";
 
 const modernNormalize = css`
   html {
@@ -42,6 +42,7 @@ const modernNormalize = css`
 
   html {
     line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
   }
 
   body {
@@ -51,11 +52,6 @@ const modernNormalize = css`
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
       "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  }
-
-  h1 {
-    font-size: 2em;
-    margin: 0.67em 0;
   }
 
   hr {
@@ -166,10 +162,6 @@ const modernNormalize = css`
   ::-webkit-file-upload-button {
     -webkit-appearance: button;
     font: inherit;
-  }
-
-  details {
-    display: block;
   }
 
   summary {


### PR DESCRIPTION
> Resolves #4

Due to breaking changes I've had to bump version to `1.0.0` since css is no longer exported.

Maybe add css only export as a named export to allow composition for stylesheets? But I think it's not needed.

I've updated all dependencies, linted and fixed files, updated readme and changelog.

Are any changes necessary?